### PR TITLE
/credentials endpoint without supplying email= or group_id= param

### DIFF
--- a/lib/accredible-api-ruby/credential.rb
+++ b/lib/accredible-api-ruby/credential.rb
@@ -23,7 +23,7 @@ module Accredible
       Accredible.request(uri, :delete)
     end
 
-    def self.view_all(group_id, email, page=1,page_size=20)
+    def self.view_all(group_id=nil, email=nil, page=1,page_size=20)
       uri = Credential.view_all_end_point(group_id, email, page, page_size)
       Accredible.request(uri)
     end
@@ -32,8 +32,17 @@ module Accredible
       Accredible.api_url("credentials/#{id}")
     end
 
-    def self.view_all_end_point(group_id, email,page=1,page_size=20)
-      Accredible.api_url("all_credentials?group_id=#{group_id}&email=#{email}&page=#{page}&page_size=#{page_size}")
+    def self.view_all_end_point(group_id=nil, email=nil,page=1,page_size=20)
+      params = {
+        page:      page,
+        page_size: page_size
+      }
+      params[:group_id] = group_id if !!group_id
+      params[:email]    = email    if !!email
+
+      param_string = params.map { |x| "#{x[0]}=#{x[1]}" }.join("&")
+
+      Accredible.api_url("all_credentials?#{param_string}")
     end
   end
 end

--- a/lib/accredible-api-ruby/credential.rb
+++ b/lib/accredible-api-ruby/credential.rb
@@ -3,7 +3,7 @@ module Accredible
 
     def self.view(id = nil)
       uri = Credential.api_end_point(id)
-      Accredible.request(uri) 
+      Accredible.request(uri)
     end
 
     def self.create(recipient:, credential:, evidence: [], references: [])
@@ -23,8 +23,8 @@ module Accredible
       Accredible.request(uri, :delete)
     end
 
-    def self.view_all(group_id=nil, email=nil, page=1,page_size=20)
-      uri = Credential.view_all_end_point(group_id, email, page, page_size)
+    def self.view_all(group_id: nil, email: nil, page: 1, page_size: 20)
+      uri = Credential.view_all_end_point(group_id: group_id, email: email, page: page, page_size: page_size)
       Accredible.request(uri)
     end
 
@@ -32,7 +32,7 @@ module Accredible
       Accredible.api_url("credentials/#{id}")
     end
 
-    def self.view_all_end_point(group_id=nil, email=nil,page=1,page_size=20)
+    def self.view_all_end_point(group_id: nil, email: nil, page: 1, page_size: 20)
       params = {
         page:      page,
         page_size: page_size

--- a/spec/accredible/base_spec.rb
+++ b/spec/accredible/base_spec.rb
@@ -13,6 +13,6 @@ describe Accredible do
 
   it "should return an error if no api key is set" do
     Accredible.api_key = nil
-    expect {Accredible::Credential.view_all("123", "example@example.com")}.to raise_error(Accredible::AuthenticationError)
+    expect {Accredible::Credential.view_all(group_id: "123", email: "example@example.com")}.to raise_error(Accredible::AuthenticationError)
   end
 end

--- a/spec/accredible/credential_spec.rb
+++ b/spec/accredible/credential_spec.rb
@@ -44,7 +44,7 @@ describe Accredible::Credential do
     end_point = credential.view_all_end_point("123", "example@example.com")
 
     expect(end_point).to include("accredible")
-    expect(end_point).to include("credentials?group_id=123&email=example@example.com")
+    expect(end_point).to include("credentials?page=1&page_size=20&group_id=123&email=example@example.com")
   end
 
 end

--- a/spec/accredible/credential_spec.rb
+++ b/spec/accredible/credential_spec.rb
@@ -2,7 +2,7 @@ describe Accredible::Credential do
   let(:credential) { Accredible::Credential }
 
   it "should return a list of credentials when view_all is called" do
-    credentials = credential.view_all("1234", "example@example.com")
+    credentials = credential.view_all(group_id: "1234", email: "example@example.com")
 
     expect(credentials).to eq("Stubbed Request")
   end
@@ -41,7 +41,7 @@ describe Accredible::Credential do
   end
 
   it "#view_all_end_point should return the view all end point" do
-    end_point = credential.view_all_end_point("123", "example@example.com")
+    end_point = credential.view_all_end_point(group_id: "123", email: "example@example.com")
 
     expect(end_point).to include("accredible")
     expect(end_point).to include("credentials?page=1&page_size=20&group_id=123&email=example@example.com")


### PR DESCRIPTION
This PR provides a way to call `Accredible::Credential.view_all()` without supplying `group_id` or `email`

Per: https://accrediblecredentialapi.docs.apiary.io/#reference/credentials/all-credentials/view-many-credentials